### PR TITLE
Updated sizing of EditButton and GoToShoppingListButton

### DIFF
--- a/src/components/PageComponents/ViewRecipePage/ViewRecipeComponents/ViewRecipeStyledButton/ViewRecipeStyledButton.jsx
+++ b/src/components/PageComponents/ViewRecipePage/ViewRecipeComponents/ViewRecipeStyledButton/ViewRecipeStyledButton.jsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 export default styled(Button)(() => ({
 	color: "black",
 	backgroundColor: "rgb(175, 175, 175)",
-	width: "200px",
+	width: "150px",
 	height: "104px",
 	border: "solid 2px black",
 	fontWeight: "bold",


### PR DESCRIPTION
- Now only 150px wide
	- Further offsets from the AddToCartButtons
	- Shows as a different action due to size change and rounded corners